### PR TITLE
Hungarian layout added for Pro1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Various keyboard layouts for the physical QWERTY keyboards of the following Andr
 
 - BlackBerry KEYone **Android 7.1 only** (Danish, Finnish, German, Norwegian, Swedish)
 - BlackBerry Priv (Danish, Finnish, German, Norwegian, Swedish)
-- F(x)tec Pro1 (Czech, Danish, Finnish, German, Norwegian, Swedish, U.S., U.S. international)
+- F(x)tec Pro1 (Czech, Danish, Finnish, German, Hungarian, Norwegian, Swedish, U.S., U.S. international)
 - Gemini PDA (Finnish, Swedish)
 - Livermorium Keyboard Moto Mod (Danish, Finnish, German, Norwegian, Swedish)
 - Motorola Droid 4 (Finnish, Swedish)

--- a/finqwerty/src/main/res/raw/pro1_qwerty_hun_1.kcm
+++ b/finqwerty/src/main/res/raw/pro1_qwerty_hun_1.kcm
@@ -1,0 +1,408 @@
+type OVERLAY
+
+# both yellow-arrow keys are 464 (FUNCTION)
+
+# orig BACK
+map key 158 ESCAPE
+
+# orig SYM but SYM does not do anything at the moment
+# so use as back/wakeup for now
+map key 249 WAKEUP
+
+# ROW 1
+
+key ESCAPE {
+    base:                               fallback BACK
+    fn:                                 fallback HOME
+}
+
+key 1 {
+    label, base:                        '1'
+    shift, alt:                         '\''
+    fn:                                 '~'
+    fn+shift, ctrl+fn:                  '\u00b9'
+}
+key 2 {
+    label, base:                        '2'
+    shift:                              '"'
+    alt:                                '"'
+    fn:                                 '\u02c7'
+    fn+shift, ctrl+fn:                  '\u030b'
+}
+key 3 {
+    label, base:                        '3'
+    shift:                              '+'
+    alt:                                '\u00a7'
+    fn:                                 '^'
+    fn+shift, ctrl+fn:                  '\u0304'
+}
+key 4 {
+    label, base:                        '4'
+    shift, alt:                         '!'
+    fn:                                 '\u02d8'
+    fn+shift, ctrl+fn:                  '\u00a3'
+}
+key 5 {
+    label, base:                        '5'
+    shift, alt:                         '%'
+    fn:                                 '\u00b0'
+    fn+shift, ctrl+fn:                  '\u0327'
+}
+key 6 {
+    label, base:                        '6'
+    shift:                              '/'
+    alt:                                '&'
+    fn:                                 '\u02db'
+    fn+shift, ctrl+fn:                  '^'
+}
+key 7 {
+    label, base:                        '7'
+    shift:                              '='
+    alt:                                '/'
+    fn:                                 '\u0060'
+    fn+shift, ctrl+fn:                  '\u031b'
+}
+key 8 {
+    label, base:                        '8'
+    shift:                              '('
+    alt:                                '('
+    fn:                                 '\u02d9'
+    fn+shift, ctrl+fn:                  '\u0328'
+}
+key 9 {
+    label, base:                        '9'
+    shift:                              ')'
+    alt:                                ')'
+    fn:                                 '\u00b4'
+    fn+shift, ctrl+fn:                  '\u0306'
+}
+key 0 {
+    label:                              '\u00d6'
+    base:                               '\u00f6'
+    shift, capslock:                    '\u00d6'
+    fn, fn+capslock:                    '0'
+    shift+fn, ctrl+fn:                  '\u00a7'
+}
+key MINUS {
+    label:                              '\u00dc'
+    base:                               '\u00fc'
+    shift, capslock:                    '\u00dc'
+    alt:                                '?'
+    fn:                                 '\u02dd'
+    fn+shift, ctrl+fn:                  '\u0323'
+}
+key EQUALS {
+    label:                              '\u00f3'
+    base:                               '\u00f3'
+    shift, capslock:                    '\u00d3'
+    alt:                                '\u0300'
+    alt+shift:                          '`'
+    fn:                                 '\u00d7'
+    fn+shift, ctrl+fn:                  '\u00f7'
+}
+
+# ROW 2
+
+# TODO NOKEY
+#key GRAVE {
+#    label:                              '`'
+#    base:                               '\u0300'
+#    shift:                              '\u0303'
+#    alt:                                '~'
+#    fn:                                 '`'
+#    fn+shift, ctrl+fn:                  '~'
+#}
+
+key Q {
+    label:                              'Q'
+    base:                               'q'
+    shift, capslock:                    'Q'
+    alt:                                '@'
+    fn:                                 '\\'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00c4'
+}
+
+key W {
+    label:                              'W'
+    base:                               'w'
+    shift, capslock:                    'W'
+    alt:                                '\u0302'
+    fn:                                 '|'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00c5'
+}
+
+key E {
+    label:                              'E'
+    base:                               'e'
+    shift, capslock:                    'E'
+    alt:                                '\u20ac'
+    #alt:                               '\u0301'
+    fn:                                 '\u00e9'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00c9'
+}
+
+key R {
+    label:                              'R'
+    base:                               'r'
+    shift, capslock:                    'R'
+    alt:                                '\u00b0'
+    fn:                                 '\u00a4'
+    fn+shift, ctrl+fn:                  '\u00a4'
+}
+
+key T {
+    label:                              'T'
+    base:                               't'
+    shift, capslock:                    'T'
+    fn:                                 '\u00fe'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00de'
+}
+
+key Y {
+    label:                              'Z'
+    base:                               'z'
+    shift, capslock:                    'Z'
+    alt:                                '|'
+    fn:                                 '\u00e6'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00c6'
+}
+
+key U {
+    label:                              'U'
+    base:                               'u'
+    shift, capslock:                    'U'
+    alt:                                '{'
+    fn:                                 '\u20ac'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00da'
+}
+
+key I {
+    label:                              'I'
+    base:                               'i'
+    shift, capslock:                    'I'
+    alt:                                '['
+    #alt:                               '\u0302'
+    fn:                                 '\u00ed'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00cd'
+}
+
+key O {
+    label:                              'O'
+    base:                               'o'
+    shift, capslock:                    'O'
+    alt:                                ']'
+    fn:                                 '\u00f3'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00d3'
+}
+
+key P {
+    label:                              'P'
+    base:                               'p'
+    shift, capslock:                    'P'
+    alt:                                '}'
+    fn:                                 '\u00f6'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00d6'
+}
+
+key LEFT_BRACKET {
+    label:                              '\u0150'
+    base:                               '\u0151'
+    shift, capslock:                    '\u0150'
+    alt:                                '\u0303'
+    fn:                                 '\u00f7'
+    fn+shift, ctrl+fn:                  '\u201c'
+}
+
+key RIGHT_BRACKET {
+    label:                              '\u00da'
+    base:                               '\u00fa'
+    shift, capslock:                    '\u00da'
+    alt:                                '*'
+    fn:                                 '\u00d7'
+    fn+shift, ctrl+fn:                  '\u201d'
+}
+
+# ROW 3
+
+key A {
+    label:                              'A'
+    base:                               'a'
+    shift, capslock:                    'A'
+    fn:                                 '\u00e1'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00c1'
+}
+
+key S {
+    label:                              'S'
+    base:                               's'
+    shift, capslock:                    'S'
+    alt:                                '\u00df'
+    fn:                                 '\u0111'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00a7'
+}
+
+key D {
+    label:                              'D'
+    base:                               'd'
+    shift, capslock:                    'D'
+    fn:                                 '\u0110'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00d0'
+}
+
+key F {
+    label:                              'F'
+    base:                               'f'
+    fn:                                 '['
+    shift, capslock:                    'F'
+}
+
+key G {
+    label:                              'G'
+    base:                               'g'
+    fn:                                 ']'
+    shift, capslock:                    'G'
+}
+
+key H {
+    label:                              'H'
+    base:                               'h'
+    alt:                                '\u0303'
+    shift, capslock:                    'H'
+}
+
+key J {
+    label:                              'J'
+    base:                               'j'
+    shift, capslock:                    'J'
+    fn:                                 '\u0171'
+}
+
+key K {
+    label:                              'K'
+    base:                               'k'
+    shift, capslock:                    'K'
+    fn, fn+capslock:                    '\u0170'
+    fn+shift, ctrl+fn:                  '\u0152'
+}
+
+key L {
+    label:                              'L'
+    base:                               'l'
+    shift, capslock:                    'L'
+    alt:                                '\''
+    fn:                                 '\u0141'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00d8'
+}
+
+key SEMICOLON {
+    label:                              '\u00e9'
+    base:                               '\u00e9'
+    shift, capslock:                    '\u00c9'
+    alt:                                '\\'
+    fn:                                 '$'
+    fn+shift, ctrl+fn:                  '\u00b0'
+}
+
+key APOSTROPHE {
+    label:                              '\u00e1'
+    base:                               '\u00e1'
+    shift, capslock:                    '\u00c1'
+    alt:                                '"'
+    fn:                                 '\u03b2'
+    fn+shift, ctrl+fn:                  '\u0308'
+}
+
+# ROW 4
+
+key BACKSLASH {
+    label:                              '\u00ed'
+    base:                               '\u00ed'
+    shift, capslock:                    '\u00cd'
+    alt:                                '>'
+    fn:                                 '<'
+    fn+shift, ctrl+fn:                  '\u00a6'
+}
+
+key Z {
+    label:                              'Y'
+    base:                               'y'
+    shift, capslock:                    'Y'
+    fn:                                 '>'
+    fn+shift, ctrl+fn:                  '\u00dc'
+}
+
+key X {
+    label:                              'X'
+    base:                               'x'
+    fn:                                 '#'
+    shift, capslock:                    'X'
+}
+
+key C {
+    label:                              'C'
+    base:                               'c'
+    shift, capslock:                    'C'
+    alt:                                '\u00e7'
+    shift+alt:                          '\u00c7'
+    fn:                                 '&'
+    fn+shift, ctrl+fn:                  '\u00a2'
+}
+
+key V {
+    label:                              'V'
+    base:                               'v'
+    fn:                                 '@'
+    shift, capslock:                    'V'
+}
+
+key B {
+    label:                              'B'
+    base:                               'b'
+    fn:                                 '{'
+    shift, capslock:                    'B'
+}
+
+key N {
+    label:                              'N'
+    base:                               'n'
+    shift, capslock:                    'N'
+    fn:                                 '}'
+    alt:                                '\u0303'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00d1'
+}
+
+key M {
+    label:                              'M'
+    base:                               'm'
+    shift, capslock:                    'M'
+    alt:                                '\u00b5'
+    fn:                                 '\u00b5'
+    fn+shift, ctrl+fn:                  '\u00b5'
+}
+
+key COMMA {
+    label:                              ','
+    base:                               ','
+    shift:                              '?'
+    alt:                                ';'
+    fn:                                 ';'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00c7'
+}
+
+key PERIOD {
+    label:                              '.'
+    base:                               '.'
+    shift:                              ':'
+    alt:                                ':'
+    fn:                                 '\u0307'
+    fn+shift, ctrl+fn:                  '\u030c'
+}
+
+key SLASH {
+    label:                              '-'
+    base:                               '-'
+    shift:                              '_'
+    alt:                                '_'
+    fn:                                 '*'
+    fn+shift, ctrl+fn:                  '\u0309'
+}

--- a/finqwerty/src/main/res/raw/pro1_qwertz_hun_1.kcm
+++ b/finqwerty/src/main/res/raw/pro1_qwertz_hun_1.kcm
@@ -1,0 +1,445 @@
+type OVERLAY
+
+# both yellow-arrow keys are 464 (FUNCTION)
+
+map key 41 Q
+map key 16 W
+map key 17 E
+map key 18 R
+map key 19 T
+map key 20 Y
+map key 21 U
+map key 22 I
+map key 23 O
+map key 24 P
+map key 25 LEFT_BRACKET
+map key 39 RIGHT_BRACKET
+
+map key 43 A
+map key 30 S
+map key 31 D
+map key 32 F
+map key 33 G
+map key 34 H
+map key 35 J
+map key 36 K
+map key 37 L
+map key 38 SEMICOLON
+map key 40 APOSTROPHE
+
+map key 26 BACKSLASH
+map key 27 Z
+map key 44 X
+map key 45 C
+map key 46 V
+map key 47 B
+map key 48 N
+map key 49 M
+map key 50 COMMA
+map key 51 PERIOD
+map key 52 SLASH
+
+# orig BACK
+map key 158 ESCAPE
+
+# orig SYM but SYM does not do anything at the moment
+# so use as back/wakeup for now
+map key 249 WAKEUP
+
+# ROW 1
+
+key ESCAPE {
+    base:                               fallback BACK
+    fn:                                 fallback HOME
+}
+
+key 1 {
+    label, base:                        '1'
+    shift, alt:                         '\''
+    fn:                                 '~'
+    fn+shift, ctrl+fn:                  '\u00b9'
+}
+key 2 {
+    label, base:                        '2'
+    shift:                              '"'
+    alt:                                '"'
+    fn:                                 '\u02c7'
+    fn+shift, ctrl+fn:                  '\u030b'
+}
+key 3 {
+    label, base:                        '3'
+    shift:                              '+'
+    alt:                                '\u00a7'
+    fn:                                 '^'
+    fn+shift, ctrl+fn:                  '\u0304'
+}
+key 4 {
+    label, base:                        '4'
+    shift, alt:                         '!'
+    fn:                                 '\u02d8'
+    fn+shift, ctrl+fn:                  '\u00a3'
+}
+key 5 {
+    label, base:                        '5'
+    shift, alt:                         '%'
+    fn:                                 '\u00b0'
+    fn+shift, ctrl+fn:                  '\u0327'
+}
+key 6 {
+    label, base:                        '6'
+    shift:                              '/'
+    alt:                                '&'
+    fn:                                 '\u02db'
+    fn+shift, ctrl+fn:                  '^'
+}
+key 7 {
+    label, base:                        '7'
+    shift:                              '='
+    alt:                                '/'
+    fn:                                 '\u0060'
+    fn+shift, ctrl+fn:                  '\u031b'
+}
+key 8 {
+    label, base:                        '8'
+    shift:                              '('
+    alt:                                '('
+    fn:                                 '\u02d9'
+    fn+shift, ctrl+fn:                  '\u0328'
+}
+key 9 {
+    label, base:                        '9'
+    shift:                              ')'
+    alt:                                ')'
+    fn:                                 '\u00b4'
+    fn+shift, ctrl+fn:                  '\u0306'
+}
+key 0 {
+    label:                              '\u00d6'
+    base:                               '\u00f6'
+    shift, capslock:                    '\u00d6'
+    fn, fn+capslock:                    '0'
+    shift+fn, ctrl+fn:                  '\u00a7'
+}
+key MINUS {
+    label:                              '\u00dc'
+    base:                               '\u00fc'
+    shift, capslock:                    '\u00dc'
+    alt:                                '?'
+    fn:                                 '\u02dd'
+    fn+shift, ctrl+fn:                  '\u0323'
+}
+key EQUALS {
+    label:                              '\u00f3'
+    base:                               '\u00f3'
+    shift, capslock:                    '\u00d3'
+    alt:                                '\u0300'
+    alt+shift:                          '`'
+    fn:                                 '\u00d7'
+    fn+shift, ctrl+fn:                  '\u00f7'
+}
+
+# ROW 2
+
+# TODO NOKEY
+#key GRAVE {
+#    label:                              '`'
+#    base:                               '\u0300'
+#    shift:                              '\u0303'
+#    alt:                                '~'
+#    fn:                                 '`'
+#    fn+shift, ctrl+fn:                  '~'
+#}
+
+key Q {
+    label:                              'Q'
+    base:                               'q'
+    shift, capslock:                    'Q'
+    alt:                                '@'
+    fn:                                 '\\'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00c4'
+}
+
+key W {
+    label:                              'W'
+    base:                               'w'
+    shift, capslock:                    'W'
+    alt:                                '\u0302'
+    fn:                                 '|'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00c5'
+}
+
+key E {
+    label:                              'E'
+    base:                               'e'
+    shift, capslock:                    'E'
+    alt:                                '\u20ac'
+    #alt:                               '\u0301'
+    fn:                                 '\u00e9'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00c9'
+}
+
+key R {
+    label:                              'R'
+    base:                               'r'
+    shift, capslock:                    'R'
+    alt:                                '\u00b0'
+    fn:                                 '\u00a4'
+    fn+shift, ctrl+fn:                  '\u00a4'
+}
+
+key T {
+    label:                              'T'
+    base:                               't'
+    shift, capslock:                    'T'
+    fn:                                 '\u00fe'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00de'
+}
+
+key Y {
+    label:                              'Z'
+    base:                               'z'
+    shift, capslock:                    'Z'
+    alt:                                '|'
+    fn:                                 '\u00e6'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00c6'
+}
+
+key U {
+    label:                              'U'
+    base:                               'u'
+    shift, capslock:                    'U'
+    alt:                                '{'
+    fn:                                 '\u20ac'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00da'
+}
+
+key I {
+    label:                              'I'
+    base:                               'i'
+    shift, capslock:                    'I'
+    alt:                                '['
+    #alt:                               '\u0302'
+    fn:                                 '\u00ed'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00cd'
+}
+
+key O {
+    label:                              'O'
+    base:                               'o'
+    shift, capslock:                    'O'
+    alt:                                ']'
+    fn:                                 '\u00f3'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00d3'
+}
+
+key P {
+    label:                              'P'
+    base:                               'p'
+    shift, capslock:                    'P'
+    alt:                                '}'
+    fn:                                 '\u00f6'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00d6'
+}
+
+key LEFT_BRACKET {
+    label:                              '\u0150'
+    base:                               '\u0151'
+    shift, capslock:                    '\u0150'
+    alt:                                '\u0303'
+    fn:                                 '\u00f7'
+    fn+shift, ctrl+fn:                  '\u201c'
+}
+
+key RIGHT_BRACKET {
+    label:                              '\u00da'
+    base:                               '\u00fa'
+    shift, capslock:                    '\u00da'
+    alt:                                '*'
+    fn:                                 '\u00d7'
+    fn+shift, ctrl+fn:                  '\u201d'
+}
+
+# ROW 3
+
+key A {
+    label:                              'A'
+    base:                               'a'
+    shift, capslock:                    'A'
+    fn:                                 '\u00e1'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00c1'
+}
+
+key S {
+    label:                              'S'
+    base:                               's'
+    shift, capslock:                    'S'
+    alt:                                '\u00df'
+    fn:                                 '\u0111'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00a7'
+}
+
+key D {
+    label:                              'D'
+    base:                               'd'
+    shift, capslock:                    'D'
+    fn:                                 '\u0110'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00d0'
+}
+
+key F {
+    label:                              'F'
+    base:                               'f'
+    fn:                                 '['
+    shift, capslock:                    'F'
+}
+
+key G {
+    label:                              'G'
+    base:                               'g'
+    fn:                                 ']'
+    shift, capslock:                    'G'
+}
+
+key H {
+    label:                              'H'
+    base:                               'h'
+    alt:                                '\u0303'
+    shift, capslock:                    'H'
+}
+
+key J {
+    label:                              'J'
+    base:                               'j'
+    shift, capslock:                    'J'
+    fn:                                 '\u0171'
+}
+
+key K {
+    label:                              'K'
+    base:                               'k'
+    shift, capslock:                    'K'
+    fn, fn+capslock:                    '\u0170'
+    fn+shift, ctrl+fn:                  '\u0152'
+}
+
+key L {
+    label:                              'L'
+    base:                               'l'
+    shift, capslock:                    'L'
+    alt:                                '\''
+    fn:                                 '\u0141'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00d8'
+}
+
+key SEMICOLON {
+    label:                              '\u00e9'
+    base:                               '\u00e9'
+    shift, capslock:                    '\u00c9'
+    alt:                                '\\'
+    fn:                                 '$'
+    fn+shift, ctrl+fn:                  '\u00b0'
+}
+
+key APOSTROPHE {
+    label:                              '\u00e1'
+    base:                               '\u00e1'
+    shift, capslock:                    '\u00c1'
+    alt:                                '"'
+    fn:                                 '\u03b2'
+    fn+shift, ctrl+fn:                  '\u0308'
+}
+
+# ROW 4
+
+key BACKSLASH {
+    label:                              '\u00ed'
+    base:                               '\u00ed'
+    shift, capslock:                    '\u00cd'
+    alt:                                '>'
+    fn:                                 '<'
+    fn+shift, ctrl+fn:                  '\u00a6'
+}
+
+key Z {
+    label:                              'Y'
+    base:                               'y'
+    shift, capslock:                    'Y'
+    fn:                                 '>'
+    fn+shift, ctrl+fn:                  '\u00dc'
+}
+
+key X {
+    label:                              'X'
+    base:                               'x'
+    fn:                                 '#'
+    shift, capslock:                    'X'
+}
+
+key C {
+    label:                              'C'
+    base:                               'c'
+    shift, capslock:                    'C'
+    alt:                                '\u00e7'
+    shift+alt:                          '\u00c7'
+    fn:                                 '&'
+    fn+shift, ctrl+fn:                  '\u00a2'
+}
+
+key V {
+    label:                              'V'
+    base:                               'v'
+    fn:                                 '@'
+    shift, capslock:                    'V'
+}
+
+key B {
+    label:                              'B'
+    base:                               'b'
+    fn:                                 '{'
+    shift, capslock:                    'B'
+}
+
+key N {
+    label:                              'N'
+    base:                               'n'
+    shift, capslock:                    'N'
+    fn:                                 '}'
+    alt:                                '\u0303'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00d1'
+}
+
+key M {
+    label:                              'M'
+    base:                               'm'
+    shift, capslock:                    'M'
+    alt:                                '\u00b5'
+    fn:                                 '\u00b5'
+    fn+shift, ctrl+fn:                  '\u00b5'
+}
+
+key COMMA {
+    label:                              ','
+    base:                               ','
+    shift:                              '?'
+    alt:                                ';'
+    fn:                                 ';'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00c7'
+}
+
+key PERIOD {
+    label:                              '.'
+    base:                               '.'
+    shift:                              ':'
+    alt:                                ':'
+    fn:                                 '\u0307'
+    fn+shift, ctrl+fn:                  '\u030c'
+}
+
+key SLASH {
+    label:                              '-'
+    base:                               '-'
+    shift:                              '_'
+    alt:                                '_'
+    fn:                                 '*'
+    fn+shift, ctrl+fn:                  '\u0309'
+}

--- a/finqwerty/src/main/res/values/strings.xml
+++ b/finqwerty/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="pro1_qwerty_cze_2">FinQwerty F(x)tec Pro1, Czech QWERTZ for physical US QWERTY</string>
     <string name="pro1_qwerty_dan_1">FinQwerty F(x)tec Pro1, Danish for physical US QWERTY</string>
     <string name="pro1_qwerty_fin_1">FinQwerty F(x)tec Pro1, Finnish for physical US QWERTY</string>
+    <string name="pro1_qwerty_hun_1">FinQwerty F(x)tec Pro1, Hungarian for physical US QWERTY</string>
     <string name="pro1_qwerty_nor_1">FinQwerty F(x)tec Pro1, Norwegian for physical US QWERTY</string>
     <string name="pro1_qwerty_swe_1">FinQwerty F(x)tec Pro1, Swedish for physical US QWERTY</string>
     <string name="pro1_qwerty_usa_1">FinQwerty F(x)tec Pro1, U.S. for physical US QWERTY</string>
@@ -39,6 +40,7 @@
     <string name="pro1_qwertz_dan_1">FinQwerty F(x)tec Pro1, Danish for physical DE QWERTZ</string>
     <string name="pro1_qwertz_fin_1">FinQwerty F(x)tec Pro1, Finnish for physical DE QWERTZ</string>
     <string name="pro1_qwertz_ger_1">FinQwerty F(x)tec Pro1, German for physical DE QWERTZ</string>
+    <string name="pro1_qwertz_hun_1">FinQwerty F(x)tec Pro1, Hungarian for physical DE QWERTZ</string>
     <string name="pro1_qwertz_nor_1">FinQwerty F(x)tec Pro1, Norwegian for physical DE QWERTZ</string>
     <string name="pro1_qwertz_swe_1">FinQwerty F(x)tec Pro1, Swedish for physical DE QWERTZ</string>
     <string name="pro1_qwertz_usa_1">FinQwerty F(x)tec Pro1, U.S. for physical DE QWERTZ</string>

--- a/finqwerty/src/main/res/xml/finqwerty_layouts.xml
+++ b/finqwerty/src/main/res/xml/finqwerty_layouts.xml
@@ -29,6 +29,7 @@
     <keyboard-layout android:name="pro1_qwerty_cze_2" android:label="@string/pro1_qwerty_cze_2" android:keyboardLayout="@raw/pro1_qwerty_cze_2"/>
     <keyboard-layout android:name="pro1_qwerty_dan_1" android:label="@string/pro1_qwerty_dan_1" android:keyboardLayout="@raw/pro1_qwerty_dan_1"/>
     <keyboard-layout android:name="pro1_qwerty_fin_1" android:label="@string/pro1_qwerty_fin_1" android:keyboardLayout="@raw/pro1_qwerty_fin_1"/>
+    <keyboard-layout android:name="pro1_qwerty_hun_1" android:label="@string/pro1_qwerty_hun_1" android:keyboardLayout="@raw/pro1_qwerty_hun_1"/>
     <keyboard-layout android:name="pro1_qwerty_nor_1" android:label="@string/pro1_qwerty_nor_1" android:keyboardLayout="@raw/pro1_qwerty_nor_1"/>
     <keyboard-layout android:name="pro1_qwerty_swe_1" android:label="@string/pro1_qwerty_swe_1" android:keyboardLayout="@raw/pro1_qwerty_swe_1"/>
     <keyboard-layout android:name="pro1_qwerty_usa_1" android:label="@string/pro1_qwerty_usa_1" android:keyboardLayout="@raw/pro1_qwerty_usa_1"/>
@@ -38,6 +39,7 @@
     <keyboard-layout android:name="pro1_qwertz_dan_1" android:label="@string/pro1_qwertz_dan_1" android:keyboardLayout="@raw/pro1_qwertz_dan_1"/>
     <keyboard-layout android:name="pro1_qwertz_fin_1" android:label="@string/pro1_qwertz_fin_1" android:keyboardLayout="@raw/pro1_qwertz_fin_1"/>
     <keyboard-layout android:name="pro1_qwertz_ger_1" android:label="@string/pro1_qwertz_ger_1" android:keyboardLayout="@raw/pro1_qwertz_ger_1"/>
+    <keyboard-layout android:name="pro1_qwertz_hun_1" android:label="@string/pro1_qwertz_hun_1" android:keyboardLayout="@raw/pro1_qwertz_hun_1"/>
     <keyboard-layout android:name="pro1_qwertz_nor_1" android:label="@string/pro1_qwertz_nor_1" android:keyboardLayout="@raw/pro1_qwertz_nor_1"/>
     <keyboard-layout android:name="pro1_qwertz_swe_1" android:label="@string/pro1_qwertz_swe_1" android:keyboardLayout="@raw/pro1_qwertz_fin_1"/>
     <keyboard-layout android:name="pro1_qwertz_usa_1" android:label="@string/pro1_qwertz_usa_1" android:keyboardLayout="@raw/pro1_qwertz_usa_1"/>


### PR DESCRIPTION
Dear @anssih,

I have modified "US. international" layout file to have a working Hungarian layout on Pro1.
National characters were placed similarly like it is written [here](https://hu.wikipedia.org/wiki/Fájl:KB_Hungary.svg).

Differences are as follow:
- I have kept numbers at the same positions as written on Pro1's keyboard, and "0" can be reached by fn+"ö" while paragraph can be reached by fn+shift+"ö" (Pro1 has a missing key in this row)
- "ű" character can be reached by fn+"j" and "Ű" character can be reached by fn+"k" (Pro1 has a missing character also in this row)

All other characters are remained in position as per Hungarian layout.

I am using QWERTZ layout on Pro1 which has a standard layout but using shifted QWERTY, accent characters may be at strange positions - however, basically it is because of the shifted layout itself.

You may find additional info [here](https://community.fxtec.com/topic/2465-qwertz-user-layout-setup/page/4/#comments)

On Pro1, these additional functions are also working:
`key DEL {`
`    fn:                                 replace BACK`
`}`

`key FORWARD_DEL {`
`    fn:                                 replace FORWARD`
`    shift:                              replace INSERT`
`}`

`key DPAD_UP {`
`    fn:                                 replace PAGE_UP`
`}`

`key DPAD_DOWN {`
`    fn:                                 replace PAGE_DOWN`
`}`

`key DPAD_LEFT {`
`    fn:                                 replace MOVE_HOME`
`}`

`key DPAD_RIGHT {`
`    fn:                                 replace MOVE_END`
`}`

These additional functions may be added in stock system later (a pull request currently exists) but they are currently not included.