### PR TITLE
Yellow keys correction

### DIFF
--- a/finqwerty/src/main/res/raw/pro1_qwerty_hun_1.kcm
+++ b/finqwerty/src/main/res/raw/pro1_qwerty_hun_1.kcm
@@ -13,12 +13,13 @@ map key 249 WAKEUP
 
 key ESCAPE {
     base:                               fallback BACK
-    fn:                                 replace HOME
+    fn:                                 fallback HOME
 }
 
 key 1 {
     label, base:                        '1'
-    shift, alt:                         '\''
+    shift:                              '\''
+    alt:                                '!'
     fn:                                 '~'
     fn+shift, ctrl+fn:                  '\u00b9'
 }
@@ -38,7 +39,8 @@ key 3 {
 }
 key 4 {
     label, base:                        '4'
-    shift, alt:                         '!'
+    shift:                              '!'
+    alt:                                '$'
     fn:                                 '\u02d8'
     fn+shift, ctrl+fn:                  '\u00a3'
 }
@@ -80,6 +82,7 @@ key 0 {
     label:                              '\u00d6'
     base:                               '\u00f6'
     shift, capslock:                    '\u00d6'
+    alt:                                '='
     fn, fn+capslock:                    '0'
     shift+fn, ctrl+fn:                  '\u00a7'
 }
@@ -307,7 +310,7 @@ key APOSTROPHE {
     label:                              '\u00e1'
     base:                               '\u00e1'
     shift, capslock:                    '\u00c1'
-    alt:                                '"'
+    alt:                                '#'
     fn:                                 '\u03b2'
     fn+shift, ctrl+fn:                  '\u0308'
 }
@@ -327,6 +330,7 @@ key Z {
     label:                              'Y'
     base:                               'y'
     shift, capslock:                    'Y'
+    alt:                                '|'
     fn:                                 '>'
     fn+shift, ctrl+fn:                  '\u00dc'
 }
@@ -402,7 +406,7 @@ key SLASH {
     label:                              '-'
     base:                               '-'
     shift:                              '_'
-    alt:                                '_'
+    alt:                                '-'
     fn:                                 '*'
     fn+shift, ctrl+fn:                  '\u0309'
 }

--- a/finqwerty/src/main/res/raw/pro1_qwerty_hun_1.kcm
+++ b/finqwerty/src/main/res/raw/pro1_qwerty_hun_1.kcm
@@ -13,7 +13,7 @@ map key 249 WAKEUP
 
 key ESCAPE {
     base:                               fallback BACK
-    fn:                                 fallback HOME
+    fn:                                 replace HOME
 }
 
 key 1 {

--- a/finqwerty/src/main/res/raw/pro1_qwertz_hun_1.kcm
+++ b/finqwerty/src/main/res/raw/pro1_qwertz_hun_1.kcm
@@ -50,7 +50,7 @@ map key 249 WAKEUP
 
 key ESCAPE {
     base:                               fallback BACK
-    fn:                                 fallback HOME
+    fn:                                 replace HOME
 }
 
 key 1 {

--- a/finqwerty/src/main/res/raw/pro1_qwertz_hun_1.kcm
+++ b/finqwerty/src/main/res/raw/pro1_qwertz_hun_1.kcm
@@ -50,12 +50,13 @@ map key 249 WAKEUP
 
 key ESCAPE {
     base:                               fallback BACK
-    fn:                                 replace HOME
+    fn:                                 fallback HOME
 }
 
 key 1 {
     label, base:                        '1'
-    shift, alt:                         '\''
+    shift:                              '\''
+    alt:                                '!'
     fn:                                 '~'
     fn+shift, ctrl+fn:                  '\u00b9'
 }
@@ -75,7 +76,8 @@ key 3 {
 }
 key 4 {
     label, base:                        '4'
-    shift, alt:                         '!'
+    shift:                              '!'
+    alt:                                '$'
     fn:                                 '\u02d8'
     fn+shift, ctrl+fn:                  '\u00a3'
 }
@@ -117,6 +119,7 @@ key 0 {
     label:                              '\u00d6'
     base:                               '\u00f6'
     shift, capslock:                    '\u00d6'
+    alt:                                '='
     fn, fn+capslock:                    '0'
     shift+fn, ctrl+fn:                  '\u00a7'
 }
@@ -344,7 +347,7 @@ key APOSTROPHE {
     label:                              '\u00e1'
     base:                               '\u00e1'
     shift, capslock:                    '\u00c1'
-    alt:                                '"'
+    alt:                                '#'
     fn:                                 '\u03b2'
     fn+shift, ctrl+fn:                  '\u0308'
 }
@@ -364,6 +367,7 @@ key Z {
     label:                              'Y'
     base:                               'y'
     shift, capslock:                    'Y'
+    alt:                                '|'
     fn:                                 '>'
     fn+shift, ctrl+fn:                  '\u00dc'
 }
@@ -439,7 +443,7 @@ key SLASH {
     label:                              '-'
     base:                               '-'
     shift:                              '_'
-    alt:                                '_'
+    alt:                                '-'
     fn:                                 '*'
     fn+shift, ctrl+fn:                  '\u0309'
 }


### PR DESCRIPTION
Dear @anssih,

I have modified Hungarian layouts to have yellow signs reachable by alt+key combinations.
I think now it should be okay.

Anyway, maybe these additional functions are also helpful:
`key DEL {`
`fn: replace BACK`
`}`

`key FORWARD_DEL {`
`fn: replace FORWARD`
`shift: replace INSERT`
`}`

...or at least back / forward function may be useful while browsing.