### PR TITLE
pro1: Added Polish keyboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Various keyboard layouts for the physical QWERTY keyboards of the following Andr
 
 - BlackBerry KEYone **Android 7.1 only** (Danish, Finnish, German, Norwegian, Swedish)
 - BlackBerry Priv (Danish, Finnish, German, Norwegian, Swedish)
-- F(x)tec Pro1 (Czech, Danish, Finnish, German, Hungarian, Norwegian, Swedish, U.S., U.S. international)
+- F(x)tec Pro1 (Czech, Danish, Finnish, German, Hungarian, Norwegian, Polish, Swedish, U.S., U.S. international)
 - Gemini PDA (Finnish, Swedish)
 - Livermorium Keyboard Moto Mod (Danish, Finnish, German, Norwegian, Swedish)
 - Motorola Droid 4 (Finnish, Swedish)

--- a/finqwerty/src/main/res/values/strings.xml
+++ b/finqwerty/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="pro1_qwerty_hun_1">FinQwerty F(x)tec Pro1, Hungarian for physical US QWERTY</string>
     <string name="pro1_qwerty_ita_1">FinQwerty F(x)tec Pro1, Italian for physical US QWERTY</string>
     <string name="pro1_qwerty_nor_1">FinQwerty F(x)tec Pro1, Norwegian for physical US QWERTY</string>
-    <string name="pro1_qwerty_pol_prog">FinQwerty F(x)tec Pro1, Polish (programmer's) for physical US QWERTY</string>
+    <string name="pro1_qwerty_pol_prog">FinQwerty F(x)tec Pro1, Polish (programmer\'s) for physical US QWERTY</string>
     <string name="pro1_qwerty_swe_1">FinQwerty F(x)tec Pro1, Swedish for physical US QWERTY</string>
     <string name="pro1_qwerty_usa_1">FinQwerty F(x)tec Pro1, U.S. for physical US QWERTY</string>
     <string name="pro1_qwerty_usaintl_1">FinQwerty F(x)tec Pro1, U.S. intl. with dead keys for physical US QWERTY</string>

--- a/finqwerty/src/main/res/values/strings.xml
+++ b/finqwerty/src/main/res/values/strings.xml
@@ -32,7 +32,7 @@
     <string name="pro1_qwerty_fin_1">FinQwerty F(x)tec Pro1, Finnish for physical US QWERTY</string>
     <string name="pro1_qwerty_hun_1">FinQwerty F(x)tec Pro1, Hungarian for physical US QWERTY</string>
     <string name="pro1_qwerty_nor_1">FinQwerty F(x)tec Pro1, Norwegian for physical US QWERTY</string>
-    <string name="pro1_qwerty_polprog_fndead">FinQwerty F(x)tec Pro1, Polish with Fn dead keys for physical US QWERTY</string>
+    <string name="pro1_qwerty_pol_prog">FinQwerty F(x)tec Pro1, Polish (programmer's) for physical US QWERTY</string>
     <string name="pro1_qwerty_swe_1">FinQwerty F(x)tec Pro1, Swedish for physical US QWERTY</string>
     <string name="pro1_qwerty_usa_1">FinQwerty F(x)tec Pro1, U.S. for physical US QWERTY</string>
     <string name="pro1_qwerty_usaintl_1">FinQwerty F(x)tec Pro1, U.S. intl. for physical US QWERTY</string>

--- a/finqwerty/src/main/res/values/strings.xml
+++ b/finqwerty/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="pro1_qwerty_fin_1">FinQwerty F(x)tec Pro1, Finnish for physical US QWERTY</string>
     <string name="pro1_qwerty_hun_1">FinQwerty F(x)tec Pro1, Hungarian for physical US QWERTY</string>
     <string name="pro1_qwerty_nor_1">FinQwerty F(x)tec Pro1, Norwegian for physical US QWERTY</string>
+    <string name="pro1_qwerty_polprog_fndead">FinQwerty F(x)tec Pro1, Polish with Fn dead keys for physical US QWERTY</string>
     <string name="pro1_qwerty_swe_1">FinQwerty F(x)tec Pro1, Swedish for physical US QWERTY</string>
     <string name="pro1_qwerty_usa_1">FinQwerty F(x)tec Pro1, U.S. for physical US QWERTY</string>
     <string name="pro1_qwerty_usaintl_1">FinQwerty F(x)tec Pro1, U.S. intl. for physical US QWERTY</string>

--- a/finqwerty/src/main/res/xml/finqwerty_layouts.xml
+++ b/finqwerty/src/main/res/xml/finqwerty_layouts.xml
@@ -31,7 +31,7 @@
     <keyboard-layout android:name="pro1_qwerty_fin_1" android:label="@string/pro1_qwerty_fin_1" android:keyboardLayout="@raw/pro1_qwerty_fin_1"/>
     <keyboard-layout android:name="pro1_qwerty_hun_1" android:label="@string/pro1_qwerty_hun_1" android:keyboardLayout="@raw/pro1_qwerty_hun_1"/>
     <keyboard-layout android:name="pro1_qwerty_nor_1" android:label="@string/pro1_qwerty_nor_1" android:keyboardLayout="@raw/pro1_qwerty_nor_1"/>
-    <keyboard-layout android:name="pro1_qwerty_polprog_fndead" android:label="@string/pro1_qwerty_polprog_fndead" android:keyboardLayout="@raw/pro1_qwerty_polprog_fndead"/>
+    <keyboard-layout android:name="pro1_qwerty_pol_prog" android:label="@string/pro1_qwerty_pol_prog" android:keyboardLayout="@raw/pro1_qwerty_pol_prog"/>
     <keyboard-layout android:name="pro1_qwerty_swe_1" android:label="@string/pro1_qwerty_swe_1" android:keyboardLayout="@raw/pro1_qwerty_swe_1"/>
     <keyboard-layout android:name="pro1_qwerty_usa_1" android:label="@string/pro1_qwerty_usa_1" android:keyboardLayout="@raw/pro1_qwerty_usa_1"/>
     <keyboard-layout android:name="pro1_qwerty_usaintl_1" android:label="@string/pro1_qwerty_usaintl_1" android:keyboardLayout="@raw/pro1_qwerty_usaintl_1"/>

--- a/finqwerty/src/main/res/xml/finqwerty_layouts.xml
+++ b/finqwerty/src/main/res/xml/finqwerty_layouts.xml
@@ -31,6 +31,7 @@
     <keyboard-layout android:name="pro1_qwerty_fin_1" android:label="@string/pro1_qwerty_fin_1" android:keyboardLayout="@raw/pro1_qwerty_fin_1"/>
     <keyboard-layout android:name="pro1_qwerty_hun_1" android:label="@string/pro1_qwerty_hun_1" android:keyboardLayout="@raw/pro1_qwerty_hun_1"/>
     <keyboard-layout android:name="pro1_qwerty_nor_1" android:label="@string/pro1_qwerty_nor_1" android:keyboardLayout="@raw/pro1_qwerty_nor_1"/>
+    <keyboard-layout android:name="pro1_qwerty_polprog_fndead" android:label="@string/pro1_qwerty_polprog_fndead" android:keyboardLayout="@raw/pro1_qwerty_polprog_fndead"/>
     <keyboard-layout android:name="pro1_qwerty_swe_1" android:label="@string/pro1_qwerty_swe_1" android:keyboardLayout="@raw/pro1_qwerty_swe_1"/>
     <keyboard-layout android:name="pro1_qwerty_usa_1" android:label="@string/pro1_qwerty_usa_1" android:keyboardLayout="@raw/pro1_qwerty_usa_1"/>
     <keyboard-layout android:name="pro1_qwerty_usaintl_1" android:label="@string/pro1_qwerty_usaintl_1" android:keyboardLayout="@raw/pro1_qwerty_usaintl_1"/>

--- a/generate_layouts.py
+++ b/generate_layouts.py
@@ -105,7 +105,7 @@ USINTL_ALTGR_REPLACE_GRAVE = [
     },
 ]
 
-USINTL_POLPROG_REPLACE = [
+USINTL_POL_PROG_REPLACE = [
     ("u00e9", "u0119"),  # é to ę
     ("u00c9", "u0118"),  # É to Ę
     ("u00e1", "u0105"),  # á to ą
@@ -210,10 +210,10 @@ key O {
 """,
     },
     {
-        NAME: "pro1_qwerty_polprog_fndead.kcm",
+        NAME: "pro1_qwerty_pol_prog.kcm",
         SOURCE: "pro1_qwerty_usaintl_fndead.kcm",
         IS_SOURCE_GENERATED: True,
-        REPLACE: USINTL_POLPROG_REPLACE,
+        REPLACE: USINTL_POL_PROG_REPLACE,
         REMOVE_KEYCODES : [
             "X",
         ],

--- a/generate_layouts.py
+++ b/generate_layouts.py
@@ -105,6 +105,26 @@ USINTL_ALTGR_REPLACE_GRAVE = [
     },
 ]
 
+USINTL_POLPROG_REPLACE = [
+    ("u00e9", "u0119"),  # é to ę
+    ("u00c9", "u0118"),  # É to Ę
+    ("u00e1", "u0105"),  # á to ą
+    ("u00c1", "u0104"),  # Á to Ą
+    {
+        REPL_KEYCODE: "S",
+        REPL_OLD: r"'\u00df'",
+        REPL_NEW: r"'\u015b'",
+        REPL_SKIP: ["alt:"],
+    },  # ß to ś (except on alt modifier)
+    ("u00a7", "u015a"),  # § to Ś
+    ("u00f8", "u0142"),  # ø to ł
+    ("u00d8", "u0141"),  # Ø to Ł
+    ("u00e6", "u017c"),  # æ to ż
+    ("u00c6", "u017b"),  # Æ to Ż
+    ("u00a9", "u0107"),  # © to ć
+    ("u00a2", "u0106"),  # ¢ to Ć
+]
+
 GENERATED_LAYOUTS = [
     {
         NAME: "pro1_qwerty_cze_1.kcm",
@@ -184,6 +204,24 @@ key O {
     shift, capslock:                    'O'
     fn:                                 '\u00e5' # å
     fn+shift, fn+capslock, fn+ctrl:     '\u00c5' # Å
+}
+""",
+    },
+    {
+        NAME: "pro1_qwerty_polprog_fndead.kcm",
+        SOURCE: "pro1_qwerty_usaintl_fndead.kcm",
+        IS_SOURCE_GENERATED: True,
+        REPLACE: USINTL_POLPROG_REPLACE,
+        REMOVE_KEYCODES : [
+            "X",
+        ],
+        ADD: r"""
+key X {
+    label:                              'X'
+    base:                               'x'
+    shift, capslock:                    'X'
+    fn:                                 '\u017a' # ź
+    fn+shift, ctrl+fn, fn+capslock:     '\u0179' # Ź
 }
 """,
     },

--- a/generate_layouts.py
+++ b/generate_layouts.py
@@ -123,6 +123,8 @@ USINTL_POLPROG_REPLACE = [
     ("u00c6", "u017b"),  # Æ to Ż
     ("u00a9", "u0107"),  # © to ć
     ("u00a2", "u0106"),  # ¢ to Ć
+    ("u00f1", "u0144"),  # ñ to ń
+    ("u00d1", "u0143"),  # Ñ to Ń
 ]
 
 GENERATED_LAYOUTS = [


### PR DESCRIPTION
As I currently have no way to enter special characters used in the Polish language via longpress, as I'm used to, I leveraged your project and created this Polish keyboard layout based on the existing US International layout with dead Fn keys.

The Polish programmer's keyboard layout is the de-facto standard layout in Poland and is used with regular US (International) QWERTY keyboards. The 6 extra characters in the Polish alphabet are accessible by using AltGr on the respective similarily looking standard characters (except for ź being on x, as ż is already on z). I left the rest of the original US International layout intact as one may want to use this layout for multiple (european) languages.

I'm currently testing this layout on my own device and it appears to work as expected.