### PR TITLE
Add Pro1 and Gemini/Cosmo Bulgarian Phonetic keyboard layouts

### DIFF
--- a/finqwerty/src/main/res/raw/gemini_bul_pho.kcm
+++ b/finqwerty/src/main/res/raw/gemini_bul_pho.kcm
@@ -1,0 +1,406 @@
+# Copyright (C) 2012 The Android Open Source Project
+# Copyright (C) 2020 Bundyo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Bulgarian Phonetic keyboard layout.
+# This is a typical Bulgarian Phonetic keyboard layout.
+#
+
+type OVERLAY
+
+### ROW 1
+
+key ESCAPE {
+    base:                               fallback BACK
+    alt, meta:                          fallback HOME
+    ctrl:                               fallback MENU
+}
+
+key 1 {
+    label:                              '1'
+    base:                               '1'
+    shift:                              '!'
+    alt:                               '\u00a1'
+    alt+shift:                         '\u00b9'
+    fn:			                		'~'
+}
+
+key 2 {
+    label:                              '2'
+    base:                               '2'
+    shift:                              '@'
+    alt:                               '\u00b2'
+    fn:				                	'`'
+}
+
+key 3 {
+    label:                              '3'
+    base:                               '3'
+    shift:                              '№'
+    alt:                                '\u00b3'
+    fn:			                		'\u00a3'
+}
+
+key 4 {
+    label:                              '4'
+    base:                               '4'
+    shift:                              '$'
+    alt:                                '\u00a4'
+    alt+shift:                          '\u00a3'
+    fn:		                			'\u20ac'
+}
+
+key 5 {
+    label:                              '5'
+    base:                               '5'
+    shift:                              '%'
+    alt:                                '\u20ac'
+    fn:		                			'<'
+}
+
+key 6 {
+    label:                              '6'
+    base:                               '6'
+    shift:                              '€'
+    alt+shift:                          '\u0302'
+    alt:                                '\u00bc'
+    fn:				                	'>'
+}
+
+key 7 {
+    label:                              '7'
+    base:                               '7'
+    shift:                              '§'
+    alt:                                '\u00bd'
+    fn:			                		'['
+}
+
+key 8 {
+    label:                              '8'
+    base:                               '8'
+    shift:                              '*'
+    alt:                                '\u00be'
+    fn:			                		']'
+}
+
+key 9 {
+    label:                              '9'
+    base:                               '9'
+    shift:                              '('
+    alt:                                '\u2018'
+    fn:					                '{'
+}
+
+key 0 {
+    label:                              '0'
+    base:                               '0'
+    shift:                              ')'
+    alt:                                '\u2019'
+    fn:					                '}'
+}
+
+key DEL {
+    base:			                	fallback DEL
+    shift:        			            fallback FORWARD_DEL
+}
+
+### ROW 2
+
+key Q {
+    label:                              '\u042f'
+    base:                               '\u044f'
+    shift, capslock:                    '\u042f'
+    alt:                                '\u00e4'
+    alt+shift, alt+capslock:            '\u00c4'
+    fn:                                 '\u0447'
+    fn+shift:                           '\u0427'
+}
+
+key W {
+    label:                              '\u0412'
+    base:                               '\u0432'
+    shift, capslock:                    '\u0412'
+    alt:                                '\u00e5'
+    alt+shift, alt+capslock:            '\u00c5'
+}
+
+key E {
+    label:                              '\u0415'
+    base:                               '\u0435'
+    shift, capslock:                    '\u0415'
+    alt:                                '\u00e9'
+    alt+shift, alt+capslock:            '\u00c9'
+}
+
+key R {
+    label:                              '\u0420'
+    base:                               '\u0440'
+    shift, capslock:                    '\u0420'
+    alt:                                '\u00ae'
+}
+
+key T {
+    label:                              '\u0422'
+    base:                               '\u0442'
+    shift, capslock:                    '\u0422'
+    alt:                                '\u00fe'
+    alt+shift, alt+capslock:            '\u00de'
+    fn:                                 '\u0448'
+    fn+shift:                           '\u0428'
+}
+
+key Y {
+    label:                              '\u042a'
+    base:                               '\u044a'
+    shift, capslock:                    '\u042a'
+    alt:                                '\u00fc'
+    alt+shift, alt+capslock:            '\u00dc'
+    fn:                                 '\u0449'
+    fn+shift:                           '\u0429'
+}
+
+key U {
+    label:                              '\u0423'
+    base:                               '\u0443'
+    shift, capslock:                    '\u0423'
+    alt:                                '\u00fa'
+    alt+shift, alt+capslock:            '\u00da'
+    fn:                                 '\u044e'
+    fn+shift:                           '\u042e'
+}
+
+key I {
+    label:                              '\u0418'
+    base:                               '\u0438'
+    shift, capslock:                    '\u0418'
+    alt:                                '\u00ed'
+    alt+shift, alt+capslock:            '\u00cd'
+    fn:				                	'+'
+}
+
+key O {
+    label:                              '\u041e'
+    base:                               '\u043e'
+    shift, capslock:                    '\u041e'
+    alt:                                '\u00f3'
+    alt+shift, alt+capslock:            '\u00d3'
+    fn:				                	'-'
+}
+
+key P {
+    label:                              '\u041f'
+    base:                               '\u043f'
+    shift, capslock:                    '\u041f'
+    alt:                                '\u00f6'
+    alt+shift, alt+capslock:            '\u00d6'
+    fn:					                '='
+}
+
+key ENTER {
+    label:                              '\n'
+    base:                               '\n'
+}
+
+### ROW 3
+
+key TAB {
+    label:                              '\t'
+    base:                               '\t'
+}
+
+key A {
+    label:                              '\u0410'
+    base:                               '\u0430'
+    shift, capslock:                    '\u0410'
+    alt:                                '\u00e1'
+    alt+shift, alt+capslock:            '\u00c1'
+}
+
+key S {
+    label:                              '\u0421'
+    base:                               '\u0441'
+    shift, capslock:                    '\u0421'
+    alt:                                '\u00df'
+    alt+shift, alt+capslock:            '\u00a7'
+}
+
+key D {
+    label:                              '\u0414'
+    base:                               '\u0434'
+    shift, capslock:                    '\u0414'
+    alt:                                '\u00f0'
+    alt+shift, alt+capslock:            '\u00d0'
+}
+
+key F {
+    label:                              '\u0424'
+    base:                               '\u0444'
+    shift, capslock:                    '\u0424'
+}
+
+key G {
+    label:                              '\u0413'
+    base:                               '\u0433'
+    shift, capslock:                    '\u0413'
+}
+
+key H {
+    label:                              '\u0425'
+    base:                               '\u0445'
+    shift, capslock:                    '\u0425'
+}
+
+key J {
+    label:                              '\u0419'
+    base:                               '\u0439'
+    shift, capslock:                    '\u0419'
+    fn:					                '_'
+}
+
+key K {
+    label:                              '\u041a'
+    base:                               '\u043a'
+    shift, capslock:                    '\u041a'
+    fn:					                ';'
+}
+
+key L {
+    label:                              '\u041b'
+    base:                               '\u043b'
+    shift, capslock:                    '\u041b'
+    alt:                                '\u00f8'
+    alt+shift, alt+capslock:            '\u00d8'
+    fn:				                	'"'
+}
+
+key APOSTROPHE {
+    label:                              '\\'
+    base:                               '\\'
+    shift:                              '|'
+    alt:                                '\u00ac'
+    alt+shift, alt+capslock:            '\u00a6'
+    fn:				                	':'
+}
+
+### ROW 4
+
+#key SHIFT_LEFT {
+#}
+
+key Z {
+    label:                              '\u0417'
+    base:                               '\u0437'
+    shift, capslock:                    '\u0417'
+    alt:                                '\u00e6'
+    alt+shift, alt+capslock:            '\u00c6'
+}
+
+key X {
+    label:                              '\u044c'
+    base:                               '\u044c'
+    shift, capslock:                    '\u045d'
+}
+
+key C {
+    label:                              '\u0426'
+    base:                               '\u0446'
+    shift, capslock:                    '\u0426'
+    alt:                                '\u00a9'
+    alt+shift, alt+capslock:            '\u00a2'
+}
+
+key V {
+    label:                              '\u0416'
+    base:                               '\u0436'
+    shift, capslock:                    '\u0416'
+}
+
+key B {
+    label:                              '\u0411'
+    base:                               '\u0431'
+    shift, capslock:                    '\u0411'
+}
+
+key N {
+    label:                              '\u041d'
+    base:                               '\u043d'
+    shift, capslock:                    '\u041d'
+    alt:                                '\u00f1'
+    alt+shift, alt+capslock:            '\u00d1'
+}
+
+key M {
+    label:                              '\u041c'
+    base:                               '\u043c'
+    shift, capslock:                    '\u041c'
+    alt:                                '\u00b5'
+    fn:				                	'\''
+}
+
+key PERIOD {
+    label:                              '.'
+    base:                               '.'
+    shift:                              '?'
+}
+
+key DPAD_UP {
+   base:			                	fallback DPAD_UP
+   fn:				                	fallback PAGE_UP
+}
+
+#key SHIFT_RIGHT {
+#}
+
+### ROW 5
+
+#key CTRL_LEFT {
+#}
+
+#key FUNCTION {
+#}
+
+#key ALT_LEFT {
+#    fn:                                 fallback SHOW_DIALER
+#}
+
+key SPACE {
+    label:                              ' '
+    base:                               ' '
+    alt, meta:                          fallback SEARCH
+    ctrl:                               fallback LANGUAGE_SWITCH
+}
+
+key COMMA {
+    label:                              ','
+    base:                               ','
+    shift:                              '/'
+    alt:                                '\u00e7'
+    alt+shift, alt+capslock:            '\u00c7'
+}
+
+key DPAD_LEFT {
+   base:				                fallback DPAD_LEFT
+   fn:				                	fallback MOVE_HOME
+}
+
+key DPAD_DOWN {
+   base:			                	fallback DPAD_DOWN
+   fn:			                		fallback PAGE_DOWN
+}
+
+key DPAD_RIGHT {
+   base:		                		fallback DPAD_RIGHT
+   fn:			                		fallback MOVE_END
+}

--- a/finqwerty/src/main/res/raw/gemini_bul_pho.kcm
+++ b/finqwerty/src/main/res/raw/gemini_bul_pho.kcm
@@ -48,7 +48,7 @@ key 2 {
 key 3 {
     label:                              '3'
     base:                               '3'
-    shift:                              '№'
+    shift:                              '\u2116'
     alt:                                '\u00b3'
     fn:			                		'\u00a3'
 }
@@ -73,7 +73,7 @@ key 5 {
 key 6 {
     label:                              '6'
     base:                               '6'
-    shift:                              '€'
+    shift:                              '\u20AC'
     alt+shift:                          '\u0302'
     alt:                                '\u00bc'
     fn:				                	'>'
@@ -82,7 +82,7 @@ key 6 {
 key 7 {
     label:                              '7'
     base:                               '7'
-    shift:                              '§'
+    shift:                              '\u00A7'
     alt:                                '\u00bd'
     fn:			                		'['
 }
@@ -124,8 +124,6 @@ key Q {
     shift, capslock:                    '\u042f'
     alt:                                '\u00e4'
     alt+shift, alt+capslock:            '\u00c4'
-    fn:                                 '\u0447'
-    fn+shift:                           '\u0427'
 }
 
 key W {
@@ -157,8 +155,6 @@ key T {
     shift, capslock:                    '\u0422'
     alt:                                '\u00fe'
     alt+shift, alt+capslock:            '\u00de'
-    fn:                                 '\u0448'
-    fn+shift:                           '\u0428'
 }
 
 key Y {
@@ -167,8 +163,8 @@ key Y {
     shift, capslock:                    '\u042a'
     alt:                                '\u00fc'
     alt+shift, alt+capslock:            '\u00dc'
-    fn:                                 '\u0449'
-    fn+shift:                           '\u0429'
+    fn:                                 '\u0448'
+    fn+shift:                           '\u0428'
 }
 
 key U {
@@ -177,8 +173,8 @@ key U {
     shift, capslock:                    '\u0423'
     alt:                                '\u00fa'
     alt+shift, alt+capslock:            '\u00da'
-    fn:                                 '\u044e'
-    fn+shift:                           '\u042e'
+    fn:                                 '\u0449'
+    fn+shift:                           '\u0429'
 }
 
 key I {
@@ -254,12 +250,16 @@ key G {
     label:                              '\u0413'
     base:                               '\u0433'
     shift, capslock:                    '\u0413'
+    fn:                                 '\u0447'
+    fn+shift:                           '\u0427'
 }
 
 key H {
     label:                              '\u0425'
     base:                               '\u0445'
     shift, capslock:                    '\u0425'
+    fn:                                 '\u044e'
+    fn+shift:                           '\u042e'
 }
 
 key J {

--- a/finqwerty/src/main/res/raw/pro1_qwerty_bul_pho.kcm
+++ b/finqwerty/src/main/res/raw/pro1_qwerty_bul_pho.kcm
@@ -1,0 +1,418 @@
+# Copyright (C) 2012 The Android Open Source Project
+# Copyright (C) 2020 Bundyo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Bulgarian Phonetic keyboard layout.
+# This is a typical Bulgarian Phonetic keyboard layout.
+#
+
+type OVERLAY
+
+# both yellow-arrow keys are 464 (FUNCTION)
+
+# orig BACK
+map key 158 ESCAPE
+
+# orig SYM but SYM does not do anything at the moment
+# so use as back/wakeup for now
+map key 249 WAKEUP
+
+# map alt+sym = F6 (which signals keyboard open), allowing one to press alt+sym
+# to trigger enabling keyboard backlight and screen rotation as sometimes the
+# Pro1 stock OS seems to lose the keyboard open state
+key WAKEUP {
+    alt:                                replace F6
+}
+
+# Y/Z swap
+map key 21 Z
+map key 44 Y
+
+# ROW 1
+
+key ESCAPE {
+    base:                               fallback BACK
+    fn:                                 replace HOME
+}
+
+key 1 {
+    label, base:                        '1'
+    shift, fn:                          '!'
+    alt:                               '\u00b9'
+    alt+shift:                         '\u00a1'
+}
+key 2 {
+    label, base:                        '2'
+    shift, fn:                          '@'
+    alt:                               '\u00b2'
+}
+key 3 {
+    label, base:                        '3'
+    shift:                              '#'
+    fn:                                 '№'
+    alt:                                '\u00b3'
+    fn+shift, ctrl+fn:                  '\u00a3'
+}
+key 4 {
+    label, base:                        '4'
+    shift:                              '$'
+    alt:                                '\u00a4'
+    alt+shift, fn+shift:                '\u00a3'
+    fn, ctrl+fn:	           			'\u20ac'
+}
+key 5 {
+    label, base:                        '5'
+    shift, fn:                          '%'
+    alt:                                '\u20ac'
+}
+key 6 {
+    label, base:                        '6'
+    shift, fn:                          '^'
+    alt+shift:                          '\u0302'
+    alt:                                '\u00bc'
+}
+
+key 7 {
+    label, base:                        '7'
+    shift:                              '§'
+    alt:                                '\u00bd'
+    fn:                                 '&'
+}
+
+key 8 {
+    label, base:                        '8'
+    shift, fn:                          '*'
+    alt:                                '\u00be'
+}
+
+key 9 {
+    label, base:                        '9'
+    shift, fn:                          '('
+    alt:                                '\u2018'
+}
+
+key 0 {
+    label, base:                        '0'
+    shift, fn:                          ')'
+    alt:                                '\u2019'
+}
+key MINUS {
+    label, base:                        '-'
+    shift, fn:                          '_'
+}
+key EQUALS {
+    label, base:                        '='
+    shift, fn:                          '+'
+}
+
+# ROW 2
+
+key TAB {
+    label:                              '\t'
+    base:                               '\t'
+}
+
+key GRAVE {
+    label:                              '\u0427'
+    base:                               '\u0447'
+    shift, capslock:                    '\u0427'
+    fn:                                 '`'
+    fn+shift, ctrl+fn:                  '~'
+}
+
+key Q {
+    label:                              '\u042f'
+    base:                               '\u044f'
+    shift, capslock:                    '\u042f'
+    alt:                                '\u00e4'
+    shift+alt, alt+capslock:            '\u00c4'
+}
+
+key W {
+    label:                              '\u0412'
+    base:                               '\u0432'
+    shift, capslock:                    '\u0412'
+    alt:                                '\u00e5'
+    shift+alt, alt+capslock:            '\u00c5'
+}
+
+key E {
+    label:                              '\u0415'
+    base:                               '\u0435'
+    shift, capslock:                    '\u0415'
+    alt:                                '\u00e9'
+    shift+alt, alt+capslock:            '\u00c9'
+}
+
+key R {
+    label:                              '\u0420'
+    base:                               '\u0440'
+    shift, capslock:                    '\u0420'
+    fn:                                 '\u00ae'
+    alt:                                '\u00a4'
+    shift+alt, alt+capslock:            '\u00a4'
+}
+
+key T {
+    label:                              '\u0422'
+    base:                               '\u0442'
+    shift, capslock:                    '\u0422'
+    alt:                                '\u00fe'
+    shift+alt, alt+capslock:            '\u00de'
+}
+
+key Y {
+    label:                              '\u042a'
+    base:                               '\u044a'
+    shift, capslock:                    '\u042a'
+    alt:                                '\u00fc'
+    shift+alt, alt+capslock:            '\u00dc'
+}
+
+key U {
+    label:                              '\u0423'
+    base:                               '\u0443'
+    shift, capslock:                    '\u0423'
+    alt:                                '\u00fa'
+    shift+alt, alt+capslock:            '\u00da'
+}
+
+key I {
+    label:                              '\u0418'
+    base:                               '\u0438'
+    shift, capslock:                    '\u0418'
+    alt:                                '\u00ed'
+    shift+alt, alt+capslock:            '\u00cd'
+}
+
+key O {
+    label:                              '\u041e'
+    base:                               '\u043e'
+    shift, capslock:                    '\u041e'
+    alt:                                '\u00f3'
+    shift+alt, alt+capslock:            '\u00d3'
+}
+
+key P {
+    label:                              '\u041f'
+    base:                               '\u043f'
+    shift, capslock:                    '\u041f'
+    alt:                                '\u00f6'
+    shift+alt, alt+capslock:            '\u00d6'
+    fn:                                 '/'
+}
+
+key SEMICOLON {
+    label:                              ';'
+    base:                               ';'
+    shift, alt:                         ':'
+    fn:                                 '\u00b7'
+    fn+shift, ctrl+fn:                  '\u00b0'
+}
+
+### ROW 3
+
+key BACKSLASH {
+    label:                              '\u042e'
+    base:                               '\u044e'
+    shift, capslock:                    '\u042e'
+    fn:                                 '\'
+    fn+shift:                           '|'
+}
+
+key A {
+    label:                              '\u0410'
+    base:                               '\u0430'
+    shift, capslock:                    '\u0410'
+    alt:                                '\u00e1'
+    shift+alt, alt+capslock:            '\u00c1'
+}
+
+key S {
+    label:                              '\u0421'
+    base:                               '\u0441'
+    shift, capslock:                    '\u0421'
+    alt:                                '\u00df'
+    shift+alt, alt+capslock:            '\u00a7'
+}
+
+key D {
+    label:                              '\u0414'
+    base:                               '\u0434'
+    shift, capslock:                    '\u0414'
+    alt:                                '\u00f0'
+    shift+alt, alt+capslock:            '\u00d0'
+}
+
+key F {
+    label:                              '\u0424'
+    base:                               '\u0444'
+    shift, capslock:                    '\u0424'
+}
+
+key G {
+    label:                              '\u0413'
+    base:                               '\u0433'
+    shift, capslock:                    '\u0413'
+}
+
+key H {
+    label:                              '\u0425'
+    base:                               '\u0445'
+    shift, capslock:                    '\u0425'
+}
+
+key J {
+    label:                              '\u0419'
+    base:                               '\u0439'
+    shift, capslock:                    '\u0419'
+    alt:                                '\u00bf'
+    shift+alt, alt+capslock:            '\u0309'
+}
+
+key K {
+    label:                              '\u041a'
+    base:                               '\u043a'
+    shift, capslock:                    '\u041a'
+    alt:                                '\u0153'
+    shift+alt, alt+capslock:            '\u0152'
+}
+
+key L {
+    label:                              '\u041b'
+    base:                               '\u043b'
+    shift, capslock:                    '\u041b'
+    alt:                                '\u00f8'
+    shift+alt, alt+capslock:            '\u00d8'
+    fn:                                 '?'
+}
+
+key APOSTROPHE {
+    label:                              '\''
+    base:                               '\''
+    shift:                              '|'
+    alt:                                '\u00ac'
+    alt+shift, alt+capslock:            '\u00a6'
+    fn:                                 '"'
+}
+
+key ENTER {
+    label:                              '\n'
+    base:                               '\n'
+}
+
+# ROW 4
+
+key LEFT_BRACKET {
+    label:                              '\u0428'
+    base:                               '\u0448'
+    shift, capslock:                    '\u0428'
+    fn:                                 '['
+    fn+shift:                           '{'
+}
+
+key RIGHT_BRACKET {
+    label:                              '\u0429'
+    base:                               '\u0449'
+    shift, capslock:                    '\u0429'
+    fn:                                 ']'
+    fn+shift:                           '}'
+}
+
+key Z {
+    label:                              '\u0417'
+    base:                               '\u0437'
+    shift, capslock:                    '\u0417'
+    alt:                                '\u00e6'
+    shift+alt, alt+capslock:            '\u00c6'
+}
+
+key X {
+    label:                              '\u044c'
+    base:                               '\u044c'
+    shift, capslock:                    '\u045d'
+}
+
+key C {
+    label:                              '\u0426'
+    base:                               '\u0446'
+    shift, capslock:                    '\u0426'
+    alt:                                '\u00e7'
+    shift+alt, alt+capslock:            '\u00c7'
+    fn:                                 '\u00a9'
+    fn+shift, ctrl+fn:                  '\u00a2'
+}
+
+key V {
+    label:                              '\u0416'
+    base:                               '\u0436'
+    shift, capslock:                    '\u0416'
+}
+
+key B {
+    label:                              '\u0411'
+    base:                               '\u0431'
+    shift, capslock:                    '\u0411'
+}
+
+key N {
+    label:                              '\u041d'
+    base:                               '\u043d'
+    shift, capslock:                    '\u041d'
+    alt:                                '\u00f1'
+    alt+shift, alt+capslock:            '\u00d1'
+}
+
+key M {
+    label:                              '\u041c'
+    base:                               '\u043c'
+    shift, capslock:                    '\u041c'
+    alt:                                '\u00b5'
+    shift+alt, alt+capslock:            '\u00b5'
+}
+
+key COMMA {
+    label:                              ','
+    base:                               ','
+    shift, alt:                         '<'
+    fn:                                 '\u00e7'
+    fn+shift, ctrl+fn, fn+capslock:     '\u00c7'
+}
+
+key PERIOD {
+    label:                              '.'
+    base:                               '.'
+    shift, alt:                         '>'
+    fn:                                 '\u0307'
+    fn+shift, ctrl+fn:                  '\u030c'
+}
+
+key DPAD_UP {
+    fn:                                 replace PAGE_UP
+}
+
+### ROW 5
+
+key DPAD_LEFT {
+    fn:                                 replace MOVE_HOME
+}
+
+key DPAD_DOWN {
+    fn:                                 replace PAGE_DOWN
+}
+
+key DPAD_RIGHT {
+    fn:                                 replace MOVE_END
+}

--- a/finqwerty/src/main/res/raw/pro1_qwerty_bul_pho.kcm
+++ b/finqwerty/src/main/res/raw/pro1_qwerty_bul_pho.kcm
@@ -36,10 +36,6 @@ key WAKEUP {
     alt:                                replace F6
 }
 
-# Y/Z swap
-map key 21 Z
-map key 44 Y
-
 # ROW 1
 
 key ESCAPE {
@@ -61,7 +57,7 @@ key 2 {
 key 3 {
     label, base:                        '3'
     shift:                              '#'
-    fn:                                 '№'
+    fn:                                 '\u2116'
     alt:                                '\u00b3'
     fn+shift, ctrl+fn:                  '\u00a3'
 }
@@ -86,7 +82,7 @@ key 6 {
 
 key 7 {
     label, base:                        '7'
-    shift:                              '§'
+    shift:                              '\u00A7'
     alt:                                '\u00bd'
     fn:                                 '&'
 }
@@ -228,7 +224,7 @@ key BACKSLASH {
     label:                              '\u042e'
     base:                               '\u044e'
     shift, capslock:                    '\u042e'
-    fn:                                 '\'
+    fn:                                 '\\'
     fn+shift:                           '|'
 }
 
@@ -300,12 +296,10 @@ key L {
 }
 
 key APOSTROPHE {
-    label:                              '\''
-    base:                               '\''
-    shift:                              '|'
+    label, base:                        '\''
+    shift, fn:                          '"'
     alt:                                '\u00ac'
     alt+shift, alt+capslock:            '\u00a6'
-    fn:                                 '"'
 }
 
 key ENTER {

--- a/finqwerty/src/main/res/raw/pro1_qwerty_bul_pho.kcm
+++ b/finqwerty/src/main/res/raw/pro1_qwerty_bul_pho.kcm
@@ -213,9 +213,9 @@ key P {
 key SEMICOLON {
     label:                              ';'
     base:                               ';'
-    shift, alt:                         ':'
-    fn:                                 '\u00b7'
-    fn+shift, ctrl+fn:                  '\u00b0'
+    shift, fn:                          ':'
+    alt:                                '\u00b7'
+    alt+shift, alt+capslock:            '\u00b0'
 }
 
 ### ROW 3
@@ -380,17 +380,17 @@ key M {
 key COMMA {
     label:                              ','
     base:                               ','
-    shift, alt:                         '<'
-    fn:                                 '\u00e7'
-    fn+shift, ctrl+fn, fn+capslock:     '\u00c7'
+    shift, fn:                          '<'
+    alt:                                '\u00e7'
+    alt+shift, alt+capslock:            '\u00c7'
 }
 
 key PERIOD {
     label:                              '.'
     base:                               '.'
-    shift, alt:                         '>'
-    fn:                                 '\u0307'
-    fn+shift, ctrl+fn:                  '\u030c'
+    shift, fn:                          '>'
+    alt:                                '\u0307'
+    alt+shift, alt+capslock:            '\u030c'
 }
 
 key DPAD_UP {

--- a/finqwerty/src/main/res/values-fi/strings.xml
+++ b/finqwerty/src/main/res/values-fi/strings.xml
@@ -43,6 +43,7 @@
     <string name="livmoto_ger_1">FinQwerty Livermorium Moto Mod, saksalainen</string>
     <string name="livmoto_nor_1">FinQwerty Livermorium Moto Mod, norjalainen</string>
     <string name="livmoto_swe_1">FinQwerty Livermorium Moto Mod, ruotsalainen</string>
+    <string name="gemini_bul_pho">FinQwerty Gemini PDA, bulgarialainen foneettiset</string>
     <string name="gemini_fin_1">FinQwerty Gemini PDA, alkuperäinen suomalainen Ä/Ö vaihdettuna</string>
     <string name="pro1_qwerty_dan_1">FinQwerty F(x)tec Pro1, tanskalainen, fyysinen QWERTY</string>
     <string name="pro1_qwerty_fin_1">FinQwerty F(x)tec Pro1, suomalainen, fyysinen QWERTY</string>
@@ -71,5 +72,6 @@
     <string name="pro1_qwerty_ita_1">FinQwerty F(x)tec Pro1, italialainen, fyysinen QWERTY</string>
     <string name="pro1_qwerty_pol_prog">FinQwerty F(x)tec Pro1, puolalainen (ohjelmoijan), fyysinen QWERTY</string>
     <string name="pro1_qwertz_che_fra">FinQwerty F(x)tec Pro1, sveitsiläinen (ranska), fyysinen QWERTZ</string>
+    <string name="pro1_qwerty_bul_pho">FinQwerty F(x)tec Pro1, bulgarialainen foneettiset, fyysinen QWERTY</string>
 
 </resources>

--- a/finqwerty/src/main/res/values/strings.xml
+++ b/finqwerty/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="keyone_nor_1">FinQwerty BlackBerry KEYone, Norwegian</string>
     <string name="keyone_ger_1">FinQwerty BlackBerry KEYone, German</string>
 
+    <string name="gemini_bul_pho">FinQwerty Gemini PDA, Bulgarian Phonetic</string>
     <string name="gemini_fin_1">FinQwerty Gemini PDA, stock Finnish/Swedish with swapped Ä/Ö</string>
 
     <string name="livmoto_fin_1">FinQwerty Livermorium Moto Mod, Finnish</string>
@@ -26,6 +27,7 @@
     <string name="livmoto_nor_1">FinQwerty Livermorium Moto Mod, Norwegian</string>
     <string name="livmoto_ger_1">FinQwerty Livermorium Moto Mod, German</string>
 
+    <string name="pro1_qwerty_bul_pho">FinQwerty F(x)tec Pro1, Bulgarian Phonetic for physical US QWERTY</string>
     <string name="pro1_qwertz_che_fra">FinQwerty F(x)tec Pro1, Swiss French for physical DE QWERTZ</string>
     <string name="pro1_qwerty_cze_1">FinQwerty F(x)tec Pro1, Czech QWERTY for physical US QWERTY</string>
     <string name="pro1_qwerty_cze_2">FinQwerty F(x)tec Pro1, Czech QWERTZ for physical US QWERTY</string>

--- a/finqwerty/src/main/res/xml/finqwerty_layouts.xml
+++ b/finqwerty/src/main/res/xml/finqwerty_layouts.xml
@@ -17,6 +17,7 @@
     <keyboard-layout android:name="keyone_dan_1" android:label="@string/keyone_dan_1" android:keyboardLayout="@raw/priv_dan_1"/>
     <keyboard-layout android:name="keyone_ger_1" android:label="@string/keyone_ger_1" android:keyboardLayout="@raw/priv_ger_1"/>
 
+    <keyboard-layout android:name="gemini_bul_pho" android:label="@string/gemini_bul_pho" android:keyboardLayout="@raw/gemini_bul_pho"/>
     <keyboard-layout android:name="gemini_fin_1" android:label="@string/gemini_fin_1" android:keyboardLayout="@raw/gemini_fin_1"/>
 
     <keyboard-layout android:name="livmoto_fin_1" android:label="@string/livmoto_fin_1" android:keyboardLayout="@raw/livmoto_fin_1"/>
@@ -25,6 +26,7 @@
     <keyboard-layout android:name="livmoto_dan_1" android:label="@string/livmoto_dan_1" android:keyboardLayout="@raw/livmoto_dan_1"/>
     <keyboard-layout android:name="livmoto_ger_1" android:label="@string/livmoto_ger_1" android:keyboardLayout="@raw/livmoto_ger_1"/>
 
+    <keyboard-layout android:name="pro1_qwerty_bul_pho" android:label="@string/pro1_qwerty_bul_pho" android:keyboardLayout="@raw/pro1_qwerty_bul_pho"/>
     <keyboard-layout android:name="pro1_qwertz_che_fra" android:label="@string/pro1_qwertz_che_fra" android:keyboardLayout="@raw/pro1_qwertz_che_fra"/>
     <keyboard-layout android:name="pro1_qwerty_cze_1" android:label="@string/pro1_qwerty_cze_1" android:keyboardLayout="@raw/pro1_qwerty_cze_1"/>
     <keyboard-layout android:name="pro1_qwerty_cze_2" android:label="@string/pro1_qwerty_cze_2" android:keyboardLayout="@raw/pro1_qwerty_cze_2"/>


### PR DESCRIPTION
Both were tested on their respected devices.

There is one gotcha - Bulgarian has 30 main characters, while English has only 26. Gemini/Cosmo have less keys than Pro1, and I had to set ШЩ то YU and ЧЮ то GH, as these are the only empty Fn keys on both devices. Same characters are on their PC respective places in Pro1 - [] and `\.